### PR TITLE
Add a starting point for functional tests

### DIFF
--- a/request_test/request_test.py
+++ b/request_test/request_test.py
@@ -36,7 +36,7 @@ def rest_request_test(request_url, request_type, request_body_dict=None, request
         response = request_type(request_url, headers=request_headers_dict, json=request_body_dict, verify=verify)
 
     logger.debug('Response status code: %d' % response.status_code)
-    assert response.status_code == expected_status,\
+    assert expected_status == response.status_code,\
         'Expected {} but got {}'.format(expected_status, response.status_code)
 
     if expected_response_dict is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ pytest-html
 
 requests
 
+flask
+
 flake8
 flake8-quotes
 flake8-docstrings

--- a/tests/functional/functional_test.py
+++ b/tests/functional/functional_test.py
@@ -1,0 +1,38 @@
+from _signal import CTRL_C_EVENT
+from _winapi import CREATE_NEW_PROCESS_GROUP
+
+import os
+from subprocess import Popen
+import requests
+import logging
+
+from tests.test_logger import logger
+from request_test.request_test import rest_request_test
+
+
+class TestFunctional(object):
+    """Perform basic functional tests using the rest_request_test function against a simple REST API."""
+
+    def setup_method(self):
+        """Set up the server for functional tests."""
+        logging.debug('Starting flask server')
+        os.environ['FLASK_APP'] = 'tests/functional/server.py'
+        logger.debug('FLASK_APP is {}'.format(os.getenv('FLASK_APP')))
+        self.server = Popen(['flask', 'run'], shell=True, creationflags=CREATE_NEW_PROCESS_GROUP)
+        assert self.server is not None
+
+    def test_basic_get(self):
+        """Confirm that a simple get against the server works as expected."""
+        response = requests.get('http://localhost:5000')
+        assert response.status_code == 200
+        logger.debug(response)
+
+        assert rest_request_test('http://localhost:5000', requests.get,
+                                 expected_response_dict={'Message': 'Hello World!'})
+
+    def teardown_method(self):
+        """Shutdown the server and cleanup from tests."""
+        # TODO: Find a way to shut down flask without feeding it a Ctrl+C; this feels clunky.
+        logger.debug('Shutting down flask server')
+        self.server.send_signal(CTRL_C_EVENT)
+        logger.info('Server terminated')

--- a/tests/functional/server.py
+++ b/tests/functional/server.py
@@ -1,0 +1,9 @@
+import json
+from flask import Flask
+app = Flask(__name__)
+
+
+@app.route('/')
+def hello():
+    """Respond with a simple 'Hello World!'."""
+    return json.dumps({'Message': 'Hello World!'})

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,10 @@
+
+import logging
+
+logger = logging.getLogger()
+handler = logging.StreamHandler()
+formatter = logging.Formatter(
+    '%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
Add a single functional test. The test starts a simple flask server that runs a single endpoint that will respond to GET requests. The test itself simply issues a GET against the endpoint using our REST service testing function and confirms the response status code and body match the expected values provided.